### PR TITLE
Improve handling and logging of unexpected errors

### DIFF
--- a/portage/L0.qmd
+++ b/portage/L0.qmd
@@ -69,6 +69,7 @@ overwrites <- 0
 errors <- 0
 
 f <- function(fn, new_dir) {
+
     basefn <- basename(fn)
     message(Sys.time(), " Processing ", basefn)
     # Try to read in the data; if it doesn't work, we won't get a data frame back
@@ -119,7 +120,15 @@ f <- function(fn, new_dir) {
                Note = note)
 }
 
-out <- lapply(files_to_process, f, new_dir = L0)
+log_info("About to L0", logfile = params$logfile)
+tryCatch({
+    out <- lapply(files_to_process, f, new_dir = L0)
+},
+error = function(e) {
+    log_warning("L0: an error occurred!", logfile = params$logfile)
+    log_info(as.character(e), logfile = params$logfile)
+    stop(e)
+})
 ```
 
 ## Summary

--- a/portage/L1_normalize.qmd
+++ b/portage/L1_normalize.qmd
@@ -214,9 +214,17 @@ f <- function(fn, out_dir, design_table) {
     return(smry)
 }
 
+log_info("About to L1_normalize", logfile = params$logfile)
+tryCatch({
 out <- lapply(files_to_process, f, 
               out_dir = L1_NORMALIZE,
               design_table = dt_ex)
+},
+error = function(e) {
+    log_warning("L1_normalize: an error occurred!", logfile = params$logfile)
+    log_info(as.character(e), logfile = params$logfile)
+    stop(e)
+})
 ```
 
 ## Summary

--- a/portage/L1a.qmd
+++ b/portage/L1a.qmd
@@ -95,8 +95,16 @@ f <- function(dir_name, dirs_to_process, out_dir) {
     return(smry)
 }
 
+log_info("About to L1a", logfile = params$logfile)
+tryCatch({
 out <- lapply(names(dirs_to_process), f, 
               dirs_to_process = dirs_to_process, out_dir = L1A)
+},
+error = function(e) {
+    log_warning("L1a: an error occurred!", logfile = params$logfile)
+    log_info(as.character(e), logfile = params$logfile)
+    stop(e)
+})
 ```
 
 ## File summary

--- a/portage/L1b.qmd
+++ b/portage/L1b.qmd
@@ -109,8 +109,16 @@ f <- function(dir_name, dirs_to_process, out_dir) {
     return(smry)
 }
 
+log_info("About to L1b", logfile = params$logfile)
+tryCatch({
 out <- lapply(names(dirs_to_process), f, 
               dirs_to_process = dirs_to_process, out_dir = L1B)
+},
+error = function(e) {
+    log_warning("L1b: an error occurred!", logfile = params$logfile)
+    log_info(as.character(e), logfile = params$logfile)
+    stop(e)
+})
 ```
 
 ## Summary

--- a/portage/driver.R
+++ b/portage/driver.R
@@ -39,9 +39,9 @@ ERROR_OCCURRED <- FALSE
 driver_try <- function(...) {
     tryCatch(eval(...),
              error = function(e) {
-                 ERROR_OCCURRED <- TRUE
-                 log_warning("An error occurred!")
-                 log_info(as.character(.Last.error))
+                 ERROR_OCCURRED <<- TRUE
+                 log_warning("Driver: an error occurred!")
+                 log_info(as.character(e))
                  if(STOP_ON_ERROR) stop(e)
              }
     )

--- a/portage/driver.R
+++ b/portage/driver.R
@@ -21,12 +21,31 @@ now_string <- function() format(Sys.time(), "%Y%m%d.%H%M")
 
 ROOT <- "./data_TEST"
 
+# Log file ----------------------------------------------------
+
 LOGS <- file.path(ROOT, "Logs/")
 
 # Main logfile
 LOGFILE <- file.path(LOGS, paste0("driver_log_", now_string(), ".txt"))
 if(file.exists(LOGFILE)) file.remove(LOGFILE)
 
+# Error handling ----------------------------------------------
+
+STOP_ON_ERROR <- TRUE
+ERROR_OCCURRED <- FALSE
+
+# driver_try: ensure that if an *unexpected* error occurs,
+# it's captured in the driver log file, and a flag is set
+driver_try <- function(...) {
+    tryCatch(eval(...),
+             error = function(e) {
+                 ERROR_OCCURRED <- TRUE
+                 log_warning("An error occurred!")
+                 log_info(as.character(.Last.error))
+                 if(STOP_ON_ERROR) stop(e)
+             }
+    )
+}
 
 # Construct L0 data ---------------------------------------------
 # L0 data are raw but in CSV form, and with "Logger" and "Table" columns added
@@ -37,10 +56,12 @@ new_section("Starting L0")
 outfile <- paste0("L0_", now_string(), ".html")
 outfile <- file.path(LOGS, outfile)
 
-quarto_render("L0.qmd",
-              execute_params = list(DATA_ROOT = ROOT,
-                                    html_outfile = outfile,
-                                    logfile = LOGFILE))
+driver_try(
+    quarto_render("L0.qmd",
+                  execute_params = list(DATA_ROOT = ROOT,
+                                        html_outfile = outfile,
+                                        logfile = LOGFILE))
+)
 copy_output("L0.html", outfile)
 
 
@@ -55,10 +76,12 @@ dt <- file.path(ROOT, "design_table.csv")
 outfile <- paste0("L1_normalize_", now_string(), ".html")
 outfile <- file.path(LOGS, outfile)
 
-quarto_render("L1_normalize.qmd",
+driver_try(
+    quarto_render("L1_normalize.qmd",
               execute_params = list(DATA_ROOT = ROOT,
                                     html_outfile = outfile,
                                     logfile = LOGFILE))
+)
 copy_output("L1_normalize.html", outfile)
 
 
@@ -76,10 +99,12 @@ new_section("Starting L1a")
 outfile <- paste0("L1a_", now_string(), ".html")
 outfile <- file.path(LOGS, outfile)
 
-quarto_render("L1a.qmd",
+driver_try(
+    quarto_render("L1a.qmd",
               execute_params = list(DATA_ROOT = ROOT,
                                     html_outfile = outfile,
                                     logfile = LOGFILE))
+)
 copy_output("L1a.html", outfile)
 
 
@@ -106,11 +131,15 @@ pt <- file.path(ROOT, "plot_table.csv")
 outfile <- paste0("L1b_", now_string(), ".html")
 outfile <- file.path(LOGS, outfile)
 
-# quarto_render("L1b.qmd",
+# driver_try(
+#     quarto_render("L1b.qmd",
 #               execute_params = list(DATA_ROOT = ROOT,
 #                                     html_outfile = outfile,
 #                                     logfile = LOGFILE))
+# )
 # copy_output("L1b.html", outfile)
 
+
+if(ERROR_OCCURRED) warning ("One or more errors occurred!")
 
 message("All done.")


### PR DESCRIPTION
As noted by @stephpenn1 in #43 , currently if an unexpected error occurs during a Quarto render it's printed to the console but the `driver.R` log file has nothing.

If an unexpected error occurs — e.g. `stop("An unexpected error!")` —  the console still has more detailed information:
```
Quitting from lines 34-51 [init] (L0.qmd)
Error:
! An unexpected error!
```
...but now with this PR the driver log file shows:
```
2023-10-04 15:23:45 WARNING: An error occurred! 
2023-10-04 15:23:45 Error in "processx::run(quarto_bin, args, echo = TRUE)": [33m![39m System command 'quarto' failed
```
In addition, an `ERROR_OCCURRED` flag is set in the driver script. This should help with current debugging and future automation. It's not ideal, but an improvement; I'm not sure how to capture that original error message without `sink`'ing the entire process, which would be a drag.
