### PR TITLE
Remove dplyr

### DIFF
--- a/portage/L1.qmd
+++ b/portage/L1.qmd
@@ -66,7 +66,7 @@ f <- function(dir_name, dirs_to_process, out_dir) {
     # everything can be stacked into a single data frame
     dat_raw <- read_csv_group(d,
                               remove_input_files = params$remove_input_files, 
-                              col_types = "ccTcccccccci")
+                              col_types = "cccccTdcccdi")
     errors <<- errors + attr(dat_raw, "errors")
     
     # File-based summary
@@ -76,7 +76,7 @@ f <- function(dir_name, dirs_to_process, out_dir) {
                        Rows = nrow(dat_raw))
     
     # Remove duplicate rows (e.g. from multiple datalogger downloads)
-    dat <- distinct(dat_raw)
+    dat <- dat_raw[!duplicated(dat_raw), ]
     message("\tRemoved ", nrow(dat_raw) - nrow(dat), " duplicate rows")
     
     # Make sure Plot (if present) and TIMESTAMP columns are on the left

--- a/portage/L1_normalize.qmd
+++ b/portage/L1_normalize.qmd
@@ -38,7 +38,6 @@ This script
 #| include: false
 
 library(tidyr)
-library(dplyr)
 library(readr)
 library(compasstools)
 if(packageVersion("compasstools") < "0.2") {
@@ -59,16 +58,14 @@ dt_ex <- compasstools::expand_df(dt)
 METADATA_VARS_TABLE <- file.path(params$DATA_ROOT, params$METADATA_VARS_TABLE)
 mt <- read_csv(METADATA_VARS_TABLE, col_types = "ccccccccddc")
 # ...and create the units table (everything must have an entry)
-mt %>% 
-    filter(!is.na(research_name)) %>% 
-    select(research_name, conversion, new_unit = final_units) ->
-    ut
+ut <- mt[!is.na(mt$research_name),] # filter
+ut$new_unit = ut$final_units # rename
+ut <- ut[c("research_name", "conversion", "new_unit")] # select
 
 # Create the bounds table (not everything needs an entry)
-mt %>% 
-    filter(!is.na(research_name), !is.na(final_units)) %>% 
-    select(research_name, units = final_units, low_bound, high_bound) ->
-    bt
+bt <- mt[!is.na(mt$research_name) & !is.na(mt$final_units),] # filter
+bt$units = bt$final_units # rename
+bt <- bt[c("research_name", "units", "low_bound", "high_bound")] # select
 
 L0 <- file.path(params$DATA_ROOT, params$L0)
 files_to_process <- list.files(L0, pattern = "*.csv$", full.names = TRUE)
@@ -117,27 +114,7 @@ f <- function(fn, out_dir, design_table) {
     # ------------- Design table
     
     # Check for missing entries in the design table
-    dat %>% 
-        anti_join(design_table,
-                  by = c("Logger", "Table", "loggernet_variable")) %>% 
-        select(Logger, Table, loggernet_variable) %>% 
-        distinct() ->
-        missings
-    
-    if(nrow(missings)) {
-        missing_dls <- paste(missings$loggernet_variable, collapse = ", ")
-        missing_dls <- strwrap(missing_dls, width = 40)
-        message("\tERROR: missing design links: ", 
-                paste(missing_dls, collapse = "\n\t\t"))
-        smry$Note <- "Missing design link row(s)"
-        errors <<- errors + 1
-        return(smry)
-    }
-    
-    # Join with design table
-    old_rows <- nrow(dat)
-    # Check that we have an design table entry for everything
-    ltlv <- paste(dat$Logger, dat$Table, dat$loggernet_variable)
+    ltlv <- unique(paste(dat$Logger, dat$Table, dat$loggernet_variable))
     present <- ltlv %in% paste(design_table$Logger, 
                                design_table$Table,
                                design_table$loggernet_variable)
@@ -145,7 +122,9 @@ f <- function(fn, out_dir, design_table) {
         stop("Some entries are missing in the design table!",
              paste(ltlv[!present], collapse = ", "))
     }
-    # Do the join
+
+    # Join with design table
+    old_rows <- nrow(dat)
     dat <- merge(dat, design_table,
                  by = c("Logger", "Table", "loggernet_variable"),
                  sort = FALSE)
@@ -189,22 +168,21 @@ f <- function(fn, out_dir, design_table) {
     # At this point everything in the value column should be numeric
     dat$value <- as.numeric(dat$value)
     dat <- compasstools::unit_conversion(dat, ut)
-    dat <- rename(dat, value_raw = value, value = value_conv)
-    dat$value_conv <- NULL
-    
+    nd <- names(dat)
+    names(dat)[nd == "value"] <- "value_raw"
+    names(dat)[nd == "value_conv"] <- "value"
+
     # ------------- Out-of-bounds flags
     
     message("\tAdding OOB flags")
-    dat %>% 
-        left_join(bt, by = c("research_name", "units")) %>% 
-        mutate(OOB = as.integer(value < low_bound | value > high_bound)) ->
-        dat
+    dat <- merge(dat, bt, by = c("research_name", "units"))
+    dat$OOB <- as.integer(with(dat, value < low_bound | value > high_bound))
     smry$`OOB%` <- round(sum(dat$OOB) / nrow(dat) * 100, 1)
     
     # Remove unneeded columns unless needed for debugging
     if(!params$debug) {
         message("\tDropping bounds columns")
-        dat <- select(dat, -low_bound, -high_bound)
+        dat$low_bound <- dat$high_bound <- NULL
     }
     
     write_to_folders(dat, 

--- a/portage/L1_normalize.qmd
+++ b/portage/L1_normalize.qmd
@@ -135,9 +135,29 @@ f <- function(fn, out_dir, design_table) {
     }
     
     # Join with design table
-    dat <- left_join(dat, design_table,
-                     by = c("Logger", "Table", "loggernet_variable"),
-                     relationship = "many-to-one")
+    old_rows <- nrow(dat)
+    # Check that we have an design table entry for everything
+    ltlv <- paste(dat$Logger, dat$Table, dat$loggernet_variable)
+    present <- ltlv %in% paste(design_table$Logger, 
+                               design_table$Table,
+                               design_table$loggernet_variable)
+    if(!all(present)) {
+        stop("Some entries are missing in the design table!",
+             paste(ltlv[!present], collapse = ", "))
+    }
+    # Do the join
+    dat <- merge(dat, design_table,
+                 by = c("Logger", "Table", "loggernet_variable"),
+                 sort = FALSE)
+    # This is a left join, and should not have changed number of rows;
+    # i.e., there must be exactly one match for every loggernet variable
+    if(nrow(dat) > old_rows) {
+        counts <- aggregate(design_link ~ loggernet_variable, data = test, 
+                            FUN = function(x) length(unique(x)))
+        counts <- counts[counts$design_link > 1,]
+        stop("Some loggernet variables have more than one design_link: ",
+             paste(counts$loggernet_variable, collapse = ", "))
+    }
     
     # Summary information
     smry$no_design_links <- sum(is.na(dat$design_link))

--- a/portage/L2.qmd
+++ b/portage/L2.qmd
@@ -30,7 +30,6 @@ This script
 #| include: false
 
 library(tidyr)
-library(dplyr)
 library(readr)
 library(lubridate)
 library(compasstools)

--- a/portage/helpers.R
+++ b/portage/helpers.R
@@ -141,7 +141,7 @@ write_to_folders <- function(x, root_dir, data_level, site,
             if(file.exists(fn)) message("NOTE: overwriting existing file")
             # We were using readr::write_csv for this but it was
             # randomly crashing on GA (Error in `vroom write()`: ! bad value)
-            write.csv(dat, fn, row.names = FALSE, na = na)
+            write.csv(dat, fn, row.names = FALSE, na = na, quote = FALSE)
             if(!file.exists(fn)) {
                 stop("File ", fn, "was not written")
             }

--- a/portage/helpers.R
+++ b/portage/helpers.R
@@ -58,7 +58,7 @@ read_csv_group <- function(files, col_types = NULL,
         x
     }
     # Store the number of errors as an attribute of the data and return
-    dat <- bind_rows(lapply(files, readf))
+    dat <- do.call("rbind", lapply(files, readf))
     attr(dat, "errors") <- errors
     dat
 }

--- a/portage/helpers.R
+++ b/portage/helpers.R
@@ -2,7 +2,6 @@
 
 library(lubridate)
 library(readr)
-library(dplyr)
 
 GIT_COMMIT <- substr(system("git rev-parse HEAD", intern = TRUE), 1, 6)
 


### PR DESCRIPTION
The first time SP tried to run this branch, she ran into a dplyr version issue 😬  

Even though `compasstools` depends on dplyr, I'd rather remove it from our synoptic pipeline. (Especially after the huge problems the [gcamdata](https://github.com/jgcri/gcamdata) folks have had with dplyr breaking changes.)

Is this OK @stephpenn1 ?

