### PR TITLE
Separate L1 data files by plot

### DIFF
--- a/synoptic/L1.qmd
+++ b/synoptic/L1.qmd
@@ -114,6 +114,7 @@ f <- function(dir_name, dirs_to_process, out_dir) {
                      root_dir = out_dir, 
                      data_level = "L1",
                      site = site,
+                     plot = dat$Plot[1],
                      version = params$L1_VERSION,
                      write_plots = params$write_plots)
     

--- a/synoptic/L1.qmd
+++ b/synoptic/L1.qmd
@@ -100,6 +100,7 @@ f <- function(dir_name, dirs_to_process, out_dir) {
                        NA_rows = sum(is.na(dat$Value)))
 
     site <- dat$Site[1]
+    plot <- dat$Plot[1]
     
     # Order columns following the column metadata...
     if(!all(column_md$Column %in% colnames(dat))) {
@@ -108,13 +109,13 @@ f <- function(dir_name, dirs_to_process, out_dir) {
     }
     dat <- dat[column_md$Column]
     # ...and sort rows
-    dat <- dat[order(dat$TIMESTAMP, dat$Plot),]
+    dat <- dat[order(dat$TIMESTAMP),]
     
     write_to_folders(dat, 
                      root_dir = out_dir, 
                      data_level = "L1",
                      site = site,
-                     plot = dat$Plot[1],
+                     plot = plot,
                      version = params$L1_VERSION,
                      write_plots = params$write_plots)
     
@@ -136,8 +137,8 @@ if(params$run_parallel) {
     library(parallel)
     apply_func = mclapply
     # L1 is memory-intensive, especially for the TEMPEST files, and 
-    # it's easy to run out of system memory, so limit cores used
-    options(mc.cores = min(3, detectCores()))
+    # it's possible to run out of system memory, so limit cores used
+    options(mc.cores = min(6, detectCores()))
     message("Using parallel::mclapply with ", getOption("mc.cores"), " cores")
 } else {
     apply_func = lapply

--- a/synoptic/L1.qmd
+++ b/synoptic/L1.qmd
@@ -95,12 +95,10 @@ f <- function(dir_name, dirs_to_process, out_dir) {
                        Files = length(d), 
                        Rows = nrow(dat),
                        NA_rows = sum(is.na(dat$Value)))
-
-    site <- dat$Site[1]
-    plot <- dat$Plot[1]
     
     if(nrow(dat)) {
         site <- dat$Site[1]
+        plot <- dat$Plot[1]
         
         # Order columns following the column metadata...
         if(!all(column_md$Column %in% colnames(dat))) {
@@ -109,12 +107,13 @@ f <- function(dir_name, dirs_to_process, out_dir) {
         }
         dat <- dat[column_md$Column]
         # ...and sort rows
-        dat <- dat[order(dat$TIMESTAMP, dat$Plot),]
+        dat <- dat[order(dat$TIMESTAMP),]
         
-        write_to_folders(dat,
-                         root_dir = out_dir,
+        write_to_folders(dat, 
+                         root_dir = out_dir, 
                          data_level = "L1",
                          site = site,
+                         plot = plot,
                          version = params$L1_VERSION,
                          write_plots = params$write_plots)
         
@@ -126,29 +125,7 @@ f <- function(dir_name, dirs_to_process, out_dir) {
         #     message("Sending ", nrow(flg), " flags to database")
         #     fdb_add_flags(site, flg)
         # }
-        
     }
-    dat <- dat[column_md$Column]
-    # ...and sort rows
-    dat <- dat[order(dat$TIMESTAMP),]
-    
-    write_to_folders(dat, 
-                     root_dir = out_dir, 
-                     data_level = "L1",
-                     site = site,
-                     plot = plot,
-                     version = params$L1_VERSION,
-                     write_plots = params$write_plots)
-    
-    # Add any OOB flags to the flag database
-    # flg <- dat[!is.na(dat$F_OOB) & dat$F_OOB == 1, "ID"]
-    # if(nrow(flg)) {
-    #     flg$Flag_type <- "OOB"
-    #     flg$Remark <- basename(dir_name)
-    #     message("Sending ", nrow(flg), " flags to database")
-    #     fdb_add_flags(site, flg)
-    # }
-
     rm(dat)
     return(smry)
 }

--- a/synoptic/L1_normalize.qmd
+++ b/synoptic/L1_normalize.qmd
@@ -250,6 +250,7 @@ f <- function(fn, out_dir, design_table) {
                      root_dir = out_dir, 
                      data_level = "L1_normalize",
                      site = dat$Site[1], 
+                     plot = dat$Plot[1],
                      logger = dat$Logger[1],
                      table = dat$Table[1])
     
@@ -264,7 +265,8 @@ f <- function(fn, out_dir, design_table) {
         write_to_folders(dat, 
                          root_dir = out_dir, 
                          data_level = "L1_normalize",
-                         site = dat$Site[1], 
+                         site = dat$Site[1],
+                         plot = dat$Plot[1],
                          logger = dat$Logger[1],
                          table = dat$Table[1])
     }

--- a/synoptic/helpers.R
+++ b/synoptic/helpers.R
@@ -81,7 +81,7 @@ read_csv_group <- function(files, col_types = NULL,
 # The data (x) should be a data frame with a POSIXct 'TIMESTAMP' column
 # This is used to split the data for sorting into <yyyy>_<mm> folders
 # Returns a list of filenames written (names) and number of data lines (values)
-write_to_folders <- function(x, root_dir, data_level, site,
+write_to_folders <- function(x, root_dir, data_level, site, plot,
                              logger, table, version = "???",
                              quiet = FALSE, write_plots = TRUE) {
     years <- year(x$TIMESTAMP)
@@ -122,7 +122,7 @@ write_to_folders <- function(x, root_dir, data_level, site,
                         format(end, format = "%Y%m%d"),
                         sep = "-")
             if(data_level == "L1_normalize") {
-                folder <- file.path(root_dir, paste(site, y, m, sep = "_"))
+                folder <- file.path(root_dir, paste(site, plot, y, m, sep = "_"))
                 # A given month's data is usually split across two datalogger
                 # files; add a short hash to end of filename to ensure we don't
                 # overwrite anything that's already there
@@ -131,7 +131,7 @@ write_to_folders <- function(x, root_dir, data_level, site,
                 na_string <- NA_STRING_L1
             } else if(data_level == "L1") {
                 folder <- file.path(root_dir, paste(site, y, sep = "_"))
-                filename <- paste0(paste(site, time_period, data_level, vversion, sep = "_"), ".csv")
+                filename <- paste0(paste(site, plot, time_period, data_level, vversion, sep = "_"), ".csv")
                 na_string <- NA_STRING_L1
                 write_this_plot <- TRUE
                 p <- ggplot(x, aes(TIMESTAMP, Value, group = paste(Plot, Instrument_ID, Sensor_ID))) +

--- a/synoptic/helpers.R
+++ b/synoptic/helpers.R
@@ -134,7 +134,7 @@ write_to_folders <- function(x, root_dir, data_level, site, plot,
                 filename <- paste0(paste(site, plot, time_period, data_level, vversion, sep = "_"), ".csv")
                 na_string <- NA_STRING_L1
                 write_this_plot <- TRUE
-                p <- ggplot(x, aes(TIMESTAMP, Value, group = paste(Plot, Instrument_ID, Sensor_ID))) +
+                p <- ggplot(x, aes(TIMESTAMP, Value, group = paste(Instrument_ID, Sensor_ID))) +
                     geom_line() +
                     facet_wrap(~research_name, scales = "free") +
                     ggtitle(filename) +

--- a/synoptic/metadata/L1_metadata/L1_metadata_columns.csv
+++ b/synoptic/metadata/L1_metadata/L1_metadata_columns.csv
@@ -1,6 +1,5 @@
 # L1 data will be ordered following rows below, and these descriptions inserted into metadata
 Column,Description
-Plot,Plot name within site (character)
 TIMESTAMP,Datalogger timestamp (EST) (POSIXct)
 Instrument,Name of measurement instrument (character)
 Instrument_ID,Identifier of instrument within plot (character)

--- a/synoptic/metadata/L1_metadata/L1_metadata_template.txt
+++ b/synoptic/metadata/L1_metadata/L1_metadata_template.txt
@@ -20,6 +20,9 @@ Site information:
 
 Files in this folder:
 —----------------------------------
+Files plot-specific, monthly, and have a naming convention of
+{SITE}_{PLOT}_{PERIOD}_{L1}_{VERSION}.csv
+
 [FILE_INFO]
 
 

--- a/synoptic/metadata/L1_metadata/L1_metadata_template.txt
+++ b/synoptic/metadata/L1_metadata/L1_metadata_template.txt
@@ -21,7 +21,7 @@ Site information:
 Files in this folder:
 —----------------------------------
 Files plot-specific, monthly, and have a naming convention of
-{SITE}_{PLOT}_{PERIOD}_{L1}_{VERSION}.csv
+{SITE}_{PLOT}_{PERIOD}_L1_{VERSION}.csv
 
 [FILE_INFO]
 


### PR DESCRIPTION
This PR changes the L1 data files from 

`{SITE}_{PERIOD}_L1_{VERSION}.csv`

to 

`{SITE}_{PLOT}_{PERIOD}_L1_{VERSION}.csv`

I.e., L1 files are now site-plot-month specific. This has a number of advantages:
* Someone ( @wilsonsj100 ?) said that Excel was warning about loading the monthly TEMPEST files, some of which exceeded 150 MB. The new plot-specific TEMPEST files are 40-50 MB at most
* It reduces memory pressure and so lets us run more R instances in parallel, speeding up the processing pipeline. Before, R would consume 10GB of memory when dealing with a single month of TEMPEST data, and now it's much lower
* Users can easily load a single plot's data with no filtering required
* The simple QAQC plots are more intelligible (b/c of fewer lines) and so hopefully more useful 

Disadvantages:
* ~3x more individual files in the data release. I don't think this is a problem

 